### PR TITLE
PHP 8.4 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         php-version:
-        - '7.4'
-        - '8.0'
         - '8.1'
-        # - '8.2'
+        - '8.2'
+        - '8.3'
+        - '8.4'
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ruler
 =====
 
-Ruler is a simple stateless production rules engine for PHP 5.3+.
+Ruler is a simple stateless production rules engine for PHP 8.1+.
 
 [![Package version](http://img.shields.io/packagist/v/ruler/ruler.svg?style=flat-square)](https://packagist.org/packages/ruler/ruler)
 [![Build status](https://img.shields.io/github/workflow/status/bobthecow/Ruler/Unit%20Tests/main.svg?style=flat-square)](https://github.com/bobthecow/Ruler/actions?query=branch:main)

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "homepage": "https://github.com/bobthecow/Ruler",
     "license": "MIT",
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.12 | ^9"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/RuleBuilder/Variable.php
+++ b/src/RuleBuilder/Variable.php
@@ -39,8 +39,8 @@ class Variable extends BaseVariable implements \ArrayAccess
      * RuleBuilder Variable constructor.
      *
      * @param RuleBuilder $ruleBuilder
-     * @param string      $name        Variable name (default: null)
-     * @param mixed       $value       Default Variable value (default: null)
+     * @param string|null $name Variable name (default: null)
+     * @param mixed $value Default Variable value (default: null)
      */
     public function __construct(RuleBuilder $ruleBuilder, ?string $name = null, mixed $value = null)
     {

--- a/src/RuleBuilder/Variable.php
+++ b/src/RuleBuilder/Variable.php
@@ -39,8 +39,8 @@ class Variable extends BaseVariable implements \ArrayAccess
      * RuleBuilder Variable constructor.
      *
      * @param RuleBuilder $ruleBuilder
-     * @param string|null $name Variable name (default: null)
-     * @param mixed $value Default Variable value (default: null)
+     * @param string|null $name         Variable name (default: null)
+     * @param mixed       $value        Default Variable value (default: null)
      */
     public function __construct(RuleBuilder $ruleBuilder, ?string $name = null, mixed $value = null)
     {
@@ -51,7 +51,7 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Get the RuleBuilder instance set on this Variable.
      */
-    public function getRuleBuilder(): RuleBuilder
+    public function getRuleBuilder() : RuleBuilder
     {
         return $this->ruleBuilder;
     }
@@ -60,10 +60,10 @@ class Variable extends BaseVariable implements \ArrayAccess
      * Get a VariableProperty for accessing methods, indexes and properties of
      * the current variable.
      *
-     * @param string $name  Property name
-     * @param mixed  $value The default VariableProperty value
+     * @param string $name Property name
+     * @param mixed $value The default VariableProperty value
      */
-    public function getProperty(string $name, $value = null): VariableProperty
+    public function getProperty(string $name, $value = null) : VariableProperty
     {
         if (!isset($this->properties[$name])) {
             $this->properties[$name] = new VariableProperty($this, $name, $value);
@@ -77,7 +77,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param string $name Property name
      */
-    public function offsetExists($name): bool
+    public function offsetExists($name) : bool
     {
         return isset($this->properties[$name]);
     }
@@ -85,11 +85,11 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Fluent interface method for creating or accessing VariableProperties.
      *
+     * @param string $name Property name
      * @see getProperty
      *
-     * @param string $name Property name
      */
-    public function offsetGet($name): VariableProperty
+    public function offsetGet($name) : VariableProperty
     {
         return $this->getProperty($name);
     }
@@ -97,12 +97,12 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Fluent interface method for setting default a VariableProperty value.
      *
+     * @param string $name Property name
+     * @param mixed $value The default Variable value
      * @see setValue
      *
-     * @param string $name  Property name
-     * @param mixed  $value The default Variable value
      */
-    public function offsetSet($name, $value): void
+    public function offsetSet($name, $value) : void
     {
         $this->getProperty($name)->setValue($value);
     }
@@ -112,7 +112,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param string $name Property name
      */
-    public function offsetUnset($name): void
+    public function offsetUnset($name) : void
     {
         unset($this->properties[$name]);
     }
@@ -122,7 +122,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function stringContains($variable): Operator\StringContains
+    public function stringContains($variable) : Operator\StringContains
     {
         return new Operator\StringContains($this, $this->asVariable($variable));
     }
@@ -132,7 +132,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function stringDoesNotContain($variable): Operator\StringDoesNotContain
+    public function stringDoesNotContain($variable) : Operator\StringDoesNotContain
     {
         return new Operator\StringDoesNotContain($this, $this->asVariable($variable));
     }
@@ -142,7 +142,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function stringContainsInsensitive($variable): Operator\StringContainsInsensitive
+    public function stringContainsInsensitive($variable) : Operator\StringContainsInsensitive
     {
         return new Operator\StringContainsInsensitive($this, $this->asVariable($variable));
     }
@@ -152,7 +152,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function greaterThan($variable): Operator\GreaterThan
+    public function greaterThan($variable) : Operator\GreaterThan
     {
         return new Operator\GreaterThan($this, $this->asVariable($variable));
     }
@@ -162,7 +162,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function greaterThanOrEqualTo($variable): Operator\GreaterThanOrEqualTo
+    public function greaterThanOrEqualTo($variable) : Operator\GreaterThanOrEqualTo
     {
         return new Operator\GreaterThanOrEqualTo($this, $this->asVariable($variable));
     }
@@ -172,7 +172,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function lessThan($variable): Operator\LessThan
+    public function lessThan($variable) : Operator\LessThan
     {
         return new Operator\LessThan($this, $this->asVariable($variable));
     }
@@ -182,7 +182,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function lessThanOrEqualTo($variable): Operator\LessThanOrEqualTo
+    public function lessThanOrEqualTo($variable) : Operator\LessThanOrEqualTo
     {
         return new Operator\LessThanOrEqualTo($this, $this->asVariable($variable));
     }
@@ -192,7 +192,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function equalTo($variable): Operator\EqualTo
+    public function equalTo($variable) : Operator\EqualTo
     {
         return new Operator\EqualTo($this, $this->asVariable($variable));
     }
@@ -202,7 +202,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function notEqualTo($variable): Operator\NotEqualTo
+    public function notEqualTo($variable) : Operator\NotEqualTo
     {
         return new Operator\NotEqualTo($this, $this->asVariable($variable));
     }
@@ -212,7 +212,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function sameAs($variable): Operator\SameAs
+    public function sameAs($variable) : Operator\SameAs
     {
         return new Operator\SameAs($this, $this->asVariable($variable));
     }
@@ -222,47 +222,47 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function notSameAs($variable): Operator\NotSameAs
+    public function notSameAs($variable) : Operator\NotSameAs
     {
         return new Operator\NotSameAs($this, $this->asVariable($variable));
     }
 
-    public function union(...$variables): self
+    public function union(...$variables) : self
     {
         return $this->applySetOperator('Union', $variables);
     }
 
-    public function intersect(...$variables): self
+    public function intersect(...$variables) : self
     {
         return $this->applySetOperator('Intersect', $variables);
     }
 
-    public function complement(...$variables): self
+    public function complement(...$variables) : self
     {
         return $this->applySetOperator('Complement', $variables);
     }
 
-    public function symmetricDifference(...$variables): self
+    public function symmetricDifference(...$variables) : self
     {
         return $this->applySetOperator('SymmetricDifference', $variables);
     }
 
-    public function min(): self
+    public function min() : self
     {
         return $this->wrap(new Operator\Min($this));
     }
 
-    public function max(): self
+    public function max() : self
     {
         return $this->wrap(new Operator\Max($this));
     }
 
-    public function containsSubset($variable): Operator\ContainsSubset
+    public function containsSubset($variable) : Operator\ContainsSubset
     {
         return new Operator\ContainsSubset($this, $this->asVariable($variable));
     }
 
-    public function doesNotContainSubset($variable): Operator\DoesNotContainSubset
+    public function doesNotContainSubset($variable) : Operator\DoesNotContainSubset
     {
         return new Operator\DoesNotContainSubset($this, $this->asVariable($variable));
     }
@@ -272,7 +272,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function setContains($variable): Operator\SetContains
+    public function setContains($variable) : Operator\SetContains
     {
         return new Operator\SetContains($this, $this->asVariable($variable));
     }
@@ -282,52 +282,52 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function setDoesNotContain($variable): Operator\SetDoesNotContain
+    public function setDoesNotContain($variable) : Operator\SetDoesNotContain
     {
         return new Operator\SetDoesNotContain($this, $this->asVariable($variable));
     }
 
-    public function add($variable): self
+    public function add($variable) : self
     {
         return $this->wrap(new Operator\Addition($this, $this->asVariable($variable)));
     }
 
-    public function divide($variable): self
+    public function divide($variable) : self
     {
         return $this->wrap(new Operator\Division($this, $this->asVariable($variable)));
     }
 
-    public function modulo($variable): self
+    public function modulo($variable) : self
     {
         return $this->wrap(new Operator\Modulo($this, $this->asVariable($variable)));
     }
 
-    public function multiply($variable): self
+    public function multiply($variable) : self
     {
         return $this->wrap(new Operator\Multiplication($this, $this->asVariable($variable)));
     }
 
-    public function subtract($variable): self
+    public function subtract($variable) : self
     {
         return $this->wrap(new Operator\Subtraction($this, $this->asVariable($variable)));
     }
 
-    public function negate(): self
+    public function negate() : self
     {
         return $this->wrap(new Operator\Negation($this));
     }
 
-    public function ceil(): self
+    public function ceil() : self
     {
         return $this->wrap(new Operator\Ceil($this));
     }
 
-    public function floor(): self
+    public function floor() : self
     {
         return $this->wrap(new Operator\Floor($this));
     }
 
-    public function exponentiate($variable): self
+    public function exponentiate($variable) : self
     {
         return $this->wrap(new Operator\Exponentiate($this, $this->asVariable($variable)));
     }
@@ -337,7 +337,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable BaseVariable instance or value
      */
-    private function asVariable($variable): BaseVariable
+    private function asVariable($variable) : BaseVariable
     {
         return ($variable instanceof BaseVariable) ? $variable : new BaseVariable(null, $variable);
     }
@@ -345,9 +345,9 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Private helper to apply a set operator.
      */
-    private function applySetOperator(string $name, array $args): self
+    private function applySetOperator(string $name, array $args) : self
     {
-        $reflection = new \ReflectionClass('\\Ruler\\Operator\\'.$name);
+        $reflection = new \ReflectionClass('\\Ruler\\Operator\\' . $name);
         \array_unshift($args, $this);
 
         return $this->wrap($reflection->newInstanceArgs($args));
@@ -356,7 +356,7 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Private helper to wrap a VariableOperator in a Variable instance.
      */
-    private function wrap(VariableOperator $op): self
+    private function wrap(VariableOperator $op) : self
     {
         return new self($this->ruleBuilder, null, $op);
     }
@@ -366,7 +366,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function endsWith($variable): Operator\EndsWith
+    public function endsWith($variable) : Operator\EndsWith
     {
         return new Operator\EndsWith($this, $this->asVariable($variable));
     }
@@ -376,7 +376,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function endsWithInsensitive($variable): Operator\EndsWithInsensitive
+    public function endsWithInsensitive($variable) : Operator\EndsWithInsensitive
     {
         return new Operator\EndsWithInsensitive($this, $this->asVariable($variable));
     }
@@ -386,7 +386,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function startsWith($variable): Operator\StartsWith
+    public function startsWith($variable) : Operator\StartsWith
     {
         return new Operator\StartsWith($this, $this->asVariable($variable));
     }
@@ -396,7 +396,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function startsWithInsensitive($variable): Operator\StartsWithInsensitive
+    public function startsWithInsensitive($variable) : Operator\StartsWithInsensitive
     {
         return new Operator\StartsWithInsensitive($this, $this->asVariable($variable));
     }
@@ -404,16 +404,16 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Magic method to apply operators registered with RuleBuilder.
      *
-     * @see RuleBuilder::registerOperatorNamespace
-     *
+     * @return Operator|self
      * @throws \LogicException if operator is not registered
      *
-     * @return Operator|self
+     * @see RuleBuilder::registerOperatorNamespace
+     *
      */
     public function __call(string $name, array $args)
     {
         $reflection = new \ReflectionClass($this->ruleBuilder->findOperator($name));
-        $args = \array_map([$this, 'asVariable'], $args);
+        $args       = \array_map([$this, 'asVariable'], $args);
         \array_unshift($args, $this);
 
         $op = $reflection->newInstanceArgs($args);

--- a/src/RuleBuilder/Variable.php
+++ b/src/RuleBuilder/Variable.php
@@ -42,7 +42,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      * @param string      $name        Variable name (default: null)
      * @param mixed       $value       Default Variable value (default: null)
      */
-    public function __construct(RuleBuilder $ruleBuilder, string $name = null, $value = null)
+    public function __construct(RuleBuilder $ruleBuilder, ?string $name = null, mixed $value = null)
     {
         $this->ruleBuilder = $ruleBuilder;
         parent::__construct($name, $value);

--- a/src/RuleBuilder/Variable.php
+++ b/src/RuleBuilder/Variable.php
@@ -39,8 +39,8 @@ class Variable extends BaseVariable implements \ArrayAccess
      * RuleBuilder Variable constructor.
      *
      * @param RuleBuilder $ruleBuilder
-     * @param string|null $name         Variable name (default: null)
-     * @param mixed       $value        Default Variable value (default: null)
+     * @param string|null $name        Variable name (default: null)
+     * @param mixed       $value       Default Variable value (default: null)
      */
     public function __construct(RuleBuilder $ruleBuilder, ?string $name = null, mixed $value = null)
     {
@@ -51,7 +51,7 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Get the RuleBuilder instance set on this Variable.
      */
-    public function getRuleBuilder() : RuleBuilder
+    public function getRuleBuilder(): RuleBuilder
     {
         return $this->ruleBuilder;
     }
@@ -60,10 +60,10 @@ class Variable extends BaseVariable implements \ArrayAccess
      * Get a VariableProperty for accessing methods, indexes and properties of
      * the current variable.
      *
-     * @param string $name Property name
-     * @param mixed $value The default VariableProperty value
+     * @param string $name  Property name
+     * @param mixed  $value The default VariableProperty value
      */
-    public function getProperty(string $name, $value = null) : VariableProperty
+    public function getProperty(string $name, $value = null): VariableProperty
     {
         if (!isset($this->properties[$name])) {
             $this->properties[$name] = new VariableProperty($this, $name, $value);
@@ -77,7 +77,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param string $name Property name
      */
-    public function offsetExists($name) : bool
+    public function offsetExists($name): bool
     {
         return isset($this->properties[$name]);
     }
@@ -86,10 +86,10 @@ class Variable extends BaseVariable implements \ArrayAccess
      * Fluent interface method for creating or accessing VariableProperties.
      *
      * @param string $name Property name
-     * @see getProperty
      *
+     * @see getProperty
      */
-    public function offsetGet($name) : VariableProperty
+    public function offsetGet($name): VariableProperty
     {
         return $this->getProperty($name);
     }
@@ -97,12 +97,12 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Fluent interface method for setting default a VariableProperty value.
      *
-     * @param string $name Property name
-     * @param mixed $value The default Variable value
-     * @see setValue
+     * @param string $name  Property name
+     * @param mixed  $value The default Variable value
      *
+     * @see setValue
      */
-    public function offsetSet($name, $value) : void
+    public function offsetSet($name, $value): void
     {
         $this->getProperty($name)->setValue($value);
     }
@@ -112,7 +112,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param string $name Property name
      */
-    public function offsetUnset($name) : void
+    public function offsetUnset($name): void
     {
         unset($this->properties[$name]);
     }
@@ -122,7 +122,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function stringContains($variable) : Operator\StringContains
+    public function stringContains($variable): Operator\StringContains
     {
         return new Operator\StringContains($this, $this->asVariable($variable));
     }
@@ -132,7 +132,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function stringDoesNotContain($variable) : Operator\StringDoesNotContain
+    public function stringDoesNotContain($variable): Operator\StringDoesNotContain
     {
         return new Operator\StringDoesNotContain($this, $this->asVariable($variable));
     }
@@ -142,7 +142,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function stringContainsInsensitive($variable) : Operator\StringContainsInsensitive
+    public function stringContainsInsensitive($variable): Operator\StringContainsInsensitive
     {
         return new Operator\StringContainsInsensitive($this, $this->asVariable($variable));
     }
@@ -152,7 +152,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function greaterThan($variable) : Operator\GreaterThan
+    public function greaterThan($variable): Operator\GreaterThan
     {
         return new Operator\GreaterThan($this, $this->asVariable($variable));
     }
@@ -162,7 +162,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function greaterThanOrEqualTo($variable) : Operator\GreaterThanOrEqualTo
+    public function greaterThanOrEqualTo($variable): Operator\GreaterThanOrEqualTo
     {
         return new Operator\GreaterThanOrEqualTo($this, $this->asVariable($variable));
     }
@@ -172,7 +172,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function lessThan($variable) : Operator\LessThan
+    public function lessThan($variable): Operator\LessThan
     {
         return new Operator\LessThan($this, $this->asVariable($variable));
     }
@@ -182,7 +182,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function lessThanOrEqualTo($variable) : Operator\LessThanOrEqualTo
+    public function lessThanOrEqualTo($variable): Operator\LessThanOrEqualTo
     {
         return new Operator\LessThanOrEqualTo($this, $this->asVariable($variable));
     }
@@ -192,7 +192,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function equalTo($variable) : Operator\EqualTo
+    public function equalTo($variable): Operator\EqualTo
     {
         return new Operator\EqualTo($this, $this->asVariable($variable));
     }
@@ -202,7 +202,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function notEqualTo($variable) : Operator\NotEqualTo
+    public function notEqualTo($variable): Operator\NotEqualTo
     {
         return new Operator\NotEqualTo($this, $this->asVariable($variable));
     }
@@ -212,7 +212,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function sameAs($variable) : Operator\SameAs
+    public function sameAs($variable): Operator\SameAs
     {
         return new Operator\SameAs($this, $this->asVariable($variable));
     }
@@ -222,47 +222,47 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function notSameAs($variable) : Operator\NotSameAs
+    public function notSameAs($variable): Operator\NotSameAs
     {
         return new Operator\NotSameAs($this, $this->asVariable($variable));
     }
 
-    public function union(...$variables) : self
+    public function union(...$variables): self
     {
         return $this->applySetOperator('Union', $variables);
     }
 
-    public function intersect(...$variables) : self
+    public function intersect(...$variables): self
     {
         return $this->applySetOperator('Intersect', $variables);
     }
 
-    public function complement(...$variables) : self
+    public function complement(...$variables): self
     {
         return $this->applySetOperator('Complement', $variables);
     }
 
-    public function symmetricDifference(...$variables) : self
+    public function symmetricDifference(...$variables): self
     {
         return $this->applySetOperator('SymmetricDifference', $variables);
     }
 
-    public function min() : self
+    public function min(): self
     {
         return $this->wrap(new Operator\Min($this));
     }
 
-    public function max() : self
+    public function max(): self
     {
         return $this->wrap(new Operator\Max($this));
     }
 
-    public function containsSubset($variable) : Operator\ContainsSubset
+    public function containsSubset($variable): Operator\ContainsSubset
     {
         return new Operator\ContainsSubset($this, $this->asVariable($variable));
     }
 
-    public function doesNotContainSubset($variable) : Operator\DoesNotContainSubset
+    public function doesNotContainSubset($variable): Operator\DoesNotContainSubset
     {
         return new Operator\DoesNotContainSubset($this, $this->asVariable($variable));
     }
@@ -272,7 +272,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function setContains($variable) : Operator\SetContains
+    public function setContains($variable): Operator\SetContains
     {
         return new Operator\SetContains($this, $this->asVariable($variable));
     }
@@ -282,52 +282,52 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function setDoesNotContain($variable) : Operator\SetDoesNotContain
+    public function setDoesNotContain($variable): Operator\SetDoesNotContain
     {
         return new Operator\SetDoesNotContain($this, $this->asVariable($variable));
     }
 
-    public function add($variable) : self
+    public function add($variable): self
     {
         return $this->wrap(new Operator\Addition($this, $this->asVariable($variable)));
     }
 
-    public function divide($variable) : self
+    public function divide($variable): self
     {
         return $this->wrap(new Operator\Division($this, $this->asVariable($variable)));
     }
 
-    public function modulo($variable) : self
+    public function modulo($variable): self
     {
         return $this->wrap(new Operator\Modulo($this, $this->asVariable($variable)));
     }
 
-    public function multiply($variable) : self
+    public function multiply($variable): self
     {
         return $this->wrap(new Operator\Multiplication($this, $this->asVariable($variable)));
     }
 
-    public function subtract($variable) : self
+    public function subtract($variable): self
     {
         return $this->wrap(new Operator\Subtraction($this, $this->asVariable($variable)));
     }
 
-    public function negate() : self
+    public function negate(): self
     {
         return $this->wrap(new Operator\Negation($this));
     }
 
-    public function ceil() : self
+    public function ceil(): self
     {
         return $this->wrap(new Operator\Ceil($this));
     }
 
-    public function floor() : self
+    public function floor(): self
     {
         return $this->wrap(new Operator\Floor($this));
     }
 
-    public function exponentiate($variable) : self
+    public function exponentiate($variable): self
     {
         return $this->wrap(new Operator\Exponentiate($this, $this->asVariable($variable)));
     }
@@ -337,7 +337,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable BaseVariable instance or value
      */
-    private function asVariable($variable) : BaseVariable
+    private function asVariable($variable): BaseVariable
     {
         return ($variable instanceof BaseVariable) ? $variable : new BaseVariable(null, $variable);
     }
@@ -345,9 +345,9 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Private helper to apply a set operator.
      */
-    private function applySetOperator(string $name, array $args) : self
+    private function applySetOperator(string $name, array $args): self
     {
-        $reflection = new \ReflectionClass('\\Ruler\\Operator\\' . $name);
+        $reflection = new \ReflectionClass('\\Ruler\\Operator\\'.$name);
         \array_unshift($args, $this);
 
         return $this->wrap($reflection->newInstanceArgs($args));
@@ -356,7 +356,7 @@ class Variable extends BaseVariable implements \ArrayAccess
     /**
      * Private helper to wrap a VariableOperator in a Variable instance.
      */
-    private function wrap(VariableOperator $op) : self
+    private function wrap(VariableOperator $op): self
     {
         return new self($this->ruleBuilder, null, $op);
     }
@@ -366,7 +366,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function endsWith($variable) : Operator\EndsWith
+    public function endsWith($variable): Operator\EndsWith
     {
         return new Operator\EndsWith($this, $this->asVariable($variable));
     }
@@ -376,7 +376,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function endsWithInsensitive($variable) : Operator\EndsWithInsensitive
+    public function endsWithInsensitive($variable): Operator\EndsWithInsensitive
     {
         return new Operator\EndsWithInsensitive($this, $this->asVariable($variable));
     }
@@ -386,7 +386,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function startsWith($variable) : Operator\StartsWith
+    public function startsWith($variable): Operator\StartsWith
     {
         return new Operator\StartsWith($this, $this->asVariable($variable));
     }
@@ -396,7 +396,7 @@ class Variable extends BaseVariable implements \ArrayAccess
      *
      * @param mixed $variable Right side of comparison operator
      */
-    public function startsWithInsensitive($variable) : Operator\StartsWithInsensitive
+    public function startsWithInsensitive($variable): Operator\StartsWithInsensitive
     {
         return new Operator\StartsWithInsensitive($this, $this->asVariable($variable));
     }
@@ -405,15 +405,15 @@ class Variable extends BaseVariable implements \ArrayAccess
      * Magic method to apply operators registered with RuleBuilder.
      *
      * @return Operator|self
+     *
      * @throws \LogicException if operator is not registered
      *
      * @see RuleBuilder::registerOperatorNamespace
-     *
      */
     public function __call(string $name, array $args)
     {
         $reflection = new \ReflectionClass($this->ruleBuilder->findOperator($name));
-        $args       = \array_map([$this, 'asVariable'], $args);
+        $args = \array_map([$this, 'asVariable'], $args);
         \array_unshift($args, $this);
 
         $op = $reflection->newInstanceArgs($args);

--- a/src/Value.php
+++ b/src/Value.php
@@ -50,7 +50,7 @@ class Value
      *
      * @return mixed
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/Value.php
+++ b/src/Value.php
@@ -21,7 +21,7 @@ namespace Ruler;
  */
 class Value
 {
-    protected $value;
+    protected mixed $value;
 
     /**
      * Value constructor.

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -31,7 +31,7 @@ class Variable implements VariableOperand
      * @param string $name  Variable name (default: null)
      * @param mixed  $value Default Variable value (default: null)
      */
-    public function __construct(string $name = null, $value = null)
+    public function __construct(?string $name = null, mixed $value = null)
     {
         $this->name = $name;
         $this->value = $value;
@@ -40,7 +40,7 @@ class Variable implements VariableOperand
     /**
      * Return the Variable name.
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -60,7 +60,7 @@ class Variable implements VariableOperand
      *
      * @return mixed Variable value
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -28,8 +28,8 @@ class Variable implements VariableOperand
     /**
      * Variable class constructor.
      *
-     * @param string $name  Variable name (default: null)
-     * @param mixed  $value Default Variable value (default: null)
+     * @param string|null $name Variable name (default: null)
+     * @param mixed $value Default Variable value (default: null)
      */
     public function __construct(?string $name = null, mixed $value = null)
     {

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -28,8 +28,8 @@ class Variable implements VariableOperand
     /**
      * Variable class constructor.
      *
-     * @param string|null $name Variable name (default: null)
-     * @param mixed $value Default Variable value (default: null)
+     * @param string|null $name  Variable name (default: null)
+     * @param mixed       $value Default Variable value (default: null)
      */
     public function __construct(?string $name = null, mixed $value = null)
     {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -25,6 +25,7 @@
 namespace Ruler\Test;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Test\Fixtures\Fact;
@@ -164,9 +165,7 @@ class ContextTest extends TestCase
         $this->assertFalse(isset($context['fact']));
     }
 
-    /**
-     * @dataProvider factDefinitionProvider
-     */
+    #[DataProvider('factDefinitionProvider')]
     public function testShare($fact)
     {
         $context = new Context();
@@ -181,9 +180,7 @@ class ContextTest extends TestCase
         $this->assertSame($factOne, $factTwo);
     }
 
-    /**
-     * @dataProvider factDefinitionProvider
-     */
+    #[DataProvider('factDefinitionProvider')]
     public function testProtect($fact)
     {
         $context = new Context();
@@ -248,9 +245,7 @@ class ContextTest extends TestCase
         $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $context['non_invokable']);
     }
 
-    /**
-     * @dataProvider badFactDefinitionProvider
-     */
+    #[DataProvider('badFactDefinitionProvider')]
     public function testShareFailsForInvalidFactDefinitions($fact)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -259,9 +254,7 @@ class ContextTest extends TestCase
         $context->share($fact);
     }
 
-    /**
-     * @dataProvider badFactDefinitionProvider
-     */
+    #[DataProvider('badFactDefinitionProvider')]
     public function testProtectFailsForInvalidFactDefinitions($fact)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -273,7 +266,7 @@ class ContextTest extends TestCase
     /**
      * Provider for invalid fact definitions.
      */
-    public function badFactDefinitionProvider()
+    public static function badFactDefinitionProvider()
     {
         return [
             [123],
@@ -284,7 +277,7 @@ class ContextTest extends TestCase
     /**
      * Provider for fact definitions.
      */
-    public function factDefinitionProvider()
+    public static function factDefinitionProvider()
     {
         return [
             [function ($value) {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -80,7 +80,7 @@ class ContextTest extends TestCase
             return new Fact();
         };
 
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $context['fact']);
+        $this->assertInstanceOf(Fact::class, $context['fact']);
     }
 
     public function testFactsShouldBeDifferent()
@@ -91,10 +91,10 @@ class ContextTest extends TestCase
         };
 
         $factOne = $context['fact'];
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $factOne);
+        $this->assertInstanceOf(Fact::class, $factOne);
 
         $factTwo = $context['fact'];
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $factTwo);
+        $this->assertInstanceOf(Fact::class, $factTwo);
 
         $this->assertNotSame($factOne, $factTwo);
     }
@@ -172,10 +172,10 @@ class ContextTest extends TestCase
         $context['shared_fact'] = $context->share($fact);
 
         $factOne = $context['shared_fact'];
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $factOne);
+        $this->assertInstanceOf(Fact::class, $factOne);
 
         $factTwo = $context['shared_fact'];
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $factTwo);
+        $this->assertInstanceOf(Fact::class, $factTwo);
 
         $this->assertSame($factOne, $factTwo);
     }
@@ -233,7 +233,7 @@ class ContextTest extends TestCase
         $context = new Context();
         $context['invokable'] = new Invokable();
 
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $context['invokable']);
+        $this->assertInstanceOf(Fact::class, $context['invokable']);
     }
 
     /** @test */
@@ -242,7 +242,7 @@ class ContextTest extends TestCase
         $context = new Context();
         $context['non_invokable'] = new Fact();
 
-        $this->assertInstanceOf(\Ruler\Test\Fixtures\Fact::class, $context['non_invokable']);
+        $this->assertInstanceOf(Fact::class, $context['non_invokable']);
     }
 
     #[DataProvider('badFactDefinitionProvider')]

--- a/tests/Functional/RulerTest.php
+++ b/tests/Functional/RulerTest.php
@@ -2,15 +2,14 @@
 
 namespace Ruler\Test\Functional;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\RuleBuilder;
 
 class RulerTest extends TestCase
 {
-    /**
-     * @dataProvider truthTableTwo
-     */
+    #[DataProvider('truthTableTwo')]
     public function testDeMorgan($p, $q)
     {
         $rb = new RuleBuilder();
@@ -37,9 +36,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableTwo
-     */
+    #[DataProvider('truthTableTwo')]
     public function testDeMorganTwo($p, $q)
     {
         $rb = new RuleBuilder();
@@ -66,9 +63,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableTwo
-     */
+    #[DataProvider('truthTableTwo')]
     public function testCommutation($p, $q)
     {
         $rb = new RuleBuilder();
@@ -89,9 +84,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableTwo
-     */
+    #[DataProvider('truthTableTwo')]
     public function testCommutationTwo($p, $q)
     {
         $rb = new RuleBuilder();
@@ -112,9 +105,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableThree
-     */
+    #[DataProvider('truthTableThree')]
     public function testAssociation($p, $q, $r)
     {
         $rb = new RuleBuilder();
@@ -141,9 +132,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableThree
-     */
+    #[DataProvider('truthTableThree')]
     public function testAssociationTwo($p, $q, $r)
     {
         $rb = new RuleBuilder();
@@ -170,9 +159,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableThree
-     */
+    #[DataProvider('truthTableThree')]
     public function testDistribution($p, $q, $r)
     {
         $rb = new RuleBuilder();
@@ -202,9 +189,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableThree
-     */
+    #[DataProvider('truthTableThree')]
     public function testDistributionTwo($p, $q, $r)
     {
         $rb = new RuleBuilder();
@@ -234,9 +219,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableOne
-     */
+    #[DataProvider('truthTableOne')]
     public function testDoubleNegation($p)
     {
         $rb = new RuleBuilder();
@@ -255,9 +238,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableOne
-     */
+    #[DataProvider('truthTableOne')]
     public function testTautology($p)
     {
         $rb = new RuleBuilder();
@@ -275,9 +256,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableOne
-     */
+    #[DataProvider('truthTableOne')]
     public function testTautologyTwo($p)
     {
         $rb = new RuleBuilder();
@@ -295,9 +274,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableOne
-     */
+    #[DataProvider('truthTableOne')]
     public function testExcludedMiddle($p)
     {
         $rb = new RuleBuilder();
@@ -315,9 +292,7 @@ class RulerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider truthTableOne
-     */
+    #[DataProvider('truthTableOne')]
     public function testNonContradiction($p)
     {
         $rb = new RuleBuilder();
@@ -337,7 +312,7 @@ class RulerTest extends TestCase
         );
     }
 
-    public function truthTableOne()
+    public static function truthTableOne()
     {
         return [
             [true],
@@ -345,7 +320,7 @@ class RulerTest extends TestCase
         ];
     }
 
-    public function truthTableTwo()
+    public static function truthTableTwo()
     {
         return [
             [true,  true],
@@ -355,7 +330,7 @@ class RulerTest extends TestCase
         ];
     }
 
-    public function truthTableThree()
+    public static function truthTableThree()
     {
         return [
             [true,  true,  true],

--- a/tests/Functional/SetTest.php
+++ b/tests/Functional/SetTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Functional;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\RuleBuilder;
@@ -36,7 +37,7 @@ class SetTest extends TestCase
         );
     }
 
-    public function setUnion()
+    public static function setUnion()
     {
         return [
             [
@@ -77,9 +78,7 @@ class SetTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setUnion
-     */
+    #[DataProvider('setUnion')]
     public function testUnion($a, $b, $expected)
     {
         $rb = new RuleBuilder();
@@ -93,7 +92,7 @@ class SetTest extends TestCase
         );
     }
 
-    public function setIntersect()
+    public static function setIntersect()
     {
         return [
             [
@@ -134,9 +133,7 @@ class SetTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setIntersect
-     */
+    #[DataProvider('setIntersect')]
     public function testIntersect($a, $b, $expected)
     {
         $rb = new RuleBuilder();
@@ -150,7 +147,7 @@ class SetTest extends TestCase
         );
     }
 
-    public function setComplement()
+    public static function setComplement()
     {
         return [
             [
@@ -191,9 +188,7 @@ class SetTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setComplement
-     */
+    #[DataProvider('setComplement')]
     public function testComplement($a, $b, $expected)
     {
         $rb = new RuleBuilder();
@@ -207,7 +202,7 @@ class SetTest extends TestCase
         );
     }
 
-    public function setSymmetricDifference()
+    public static function setSymmetricDifference()
     {
         return [
             [
@@ -248,9 +243,7 @@ class SetTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setSymmetricDifference
-     */
+    #[DataProvider('setSymmetricDifference')]
     public function testSymmetricDifference($a, $b, $expected)
     {
         $rb = new RuleBuilder();

--- a/tests/Operator/AdditionTest.php
+++ b/tests/Operator/AdditionTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -30,9 +31,7 @@ class AdditionTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider additionData
-     */
+    #[DataProvider('additionData')]
     public function testAddition($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -43,7 +42,7 @@ class AdditionTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function additionData()
+    public static function additionData()
     {
         return [
             [1, 2, 3],

--- a/tests/Operator/CeilTest.php
+++ b/tests/Operator/CeilTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -28,9 +29,7 @@ class CeilTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider ceilingData
-     */
+    #[DataProvider('ceilingData')]
     public function testCeiling($a, $result)
     {
         $varA = new Variable('a', $a);
@@ -40,7 +39,7 @@ class CeilTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function ceilingData()
+    public static function ceilingData()
     {
         return [
             [1.2, 2],

--- a/tests/Operator/ComplementTest.php
+++ b/tests/Operator/ComplementTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -31,9 +32,7 @@ class ComplementTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider complementData
-     */
+    #[DataProvider('complementData')]
     public function testComplement($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -47,7 +46,7 @@ class ComplementTest extends TestCase
         );
     }
 
-    public function complementData()
+    public static function complementData()
     {
         return [
             [6, 2, [6]],

--- a/tests/Operator/ContainsSubsetTest.php
+++ b/tests/Operator/ContainsSubsetTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -18,9 +19,7 @@ class ContainsSubsetTest extends TestCase
         $this->assertInstanceOf(\Ruler\Proposition::class, $op);
     }
 
-    /**
-     * @dataProvider containsData
-     */
+    #[DataProvider('containsData')]
     public function testContains($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -31,9 +30,7 @@ class ContainsSubsetTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    /**
-     * @dataProvider containsData
-     */
+    #[DataProvider('containsData')]
     public function testDoesNotContain($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -44,7 +41,7 @@ class ContainsSubsetTest extends TestCase
         $this->assertNotEquals($op->evaluate($context), $result);
     }
 
-    public function containsData()
+    public static function containsData()
     {
         return [
             [[1], [1], true],

--- a/tests/Operator/DivisionTest.php
+++ b/tests/Operator/DivisionTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -42,9 +43,7 @@ class DivisionTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider divisionData
-     */
+    #[DataProvider('divisionData')]
     public function testDivision($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -55,7 +54,7 @@ class DivisionTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function divisionData()
+    public static function divisionData()
     {
         return [
             [6, 2, 3],

--- a/tests/Operator/EndsWithInsensitiveTest.php
+++ b/tests/Operator/EndsWithInsensitiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -18,9 +19,7 @@ class EndsWithInsensitiveTest extends TestCase
         $this->assertInstanceOf(\Ruler\Proposition::class, $op);
     }
 
-    /**
-     * @dataProvider endsWithData
-     */
+    #[DataProvider('endsWithData')]
     public function testEndsWithInsensitive($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -31,7 +30,7 @@ class EndsWithInsensitiveTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    public function endsWithData()
+    public static function endsWithData()
     {
         return [
             ['supercalifragilistic', 'supercalifragilistic', true],

--- a/tests/Operator/EndsWithTest.php
+++ b/tests/Operator/EndsWithTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -18,9 +19,7 @@ class EndsWithTest extends TestCase
         $this->assertInstanceOf(\Ruler\Proposition::class, $op);
     }
 
-    /**
-     * @dataProvider endsWithData
-     */
+    #[DataProvider('endsWithData')]
     public function testEndsWith($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -31,7 +30,7 @@ class EndsWithTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    public function endsWithData()
+    public static function endsWithData()
     {
         return [
             ['supercalifragilistic', 'supercalifragilistic', true],

--- a/tests/Operator/ExponentiateTest.php
+++ b/tests/Operator/ExponentiateTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -30,9 +31,7 @@ class ExponentiateTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider exponentiateData
-     */
+    #[DataProvider('exponentiateData')]
     public function testExponentiate($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -43,7 +42,7 @@ class ExponentiateTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function exponentiateData()
+    public static function exponentiateData()
     {
         return [
             [6, 2, 36],

--- a/tests/Operator/FloorTest.php
+++ b/tests/Operator/FloorTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -28,9 +29,7 @@ class FloorTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider ceilingData
-     */
+    #[DataProvider('ceilingData')]
     public function testCeiling($a, $result)
     {
         $varA = new Variable('a', $a);
@@ -40,7 +39,7 @@ class FloorTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function ceilingData()
+    public static function ceilingData()
     {
         return [
             [1.2, 1],

--- a/tests/Operator/IntersectTest.php
+++ b/tests/Operator/IntersectTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -31,9 +32,7 @@ class IntersectTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider intersectData
-     */
+    #[DataProvider('intersectData')]
     public function testIntersect($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -47,7 +46,7 @@ class IntersectTest extends TestCase
         );
     }
 
-    public function intersectData()
+    public static function intersectData()
     {
         return [
             [6, 2, []],

--- a/tests/Operator/MaxTest.php
+++ b/tests/Operator/MaxTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -17,9 +18,7 @@ class MaxTest extends TestCase
         $this->assertInstanceOf(\Ruler\VariableOperand::class, $op);
     }
 
-    /**
-     * @dataProvider invalidData
-     */
+    #[DataProvider('invalidData')]
     public function testInvalidData($datum)
     {
         $this->expectException(\RuntimeException::class);
@@ -31,7 +30,7 @@ class MaxTest extends TestCase
         $op->prepareValue($context);
     }
 
-    public function invalidData()
+    public static function invalidData()
     {
         return [
             ['string'],
@@ -41,9 +40,7 @@ class MaxTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider maxData
-     */
+    #[DataProvider('maxData')]
     public function testMax($a, $result)
     {
         $var = new Variable('a', $a);
@@ -56,7 +53,7 @@ class MaxTest extends TestCase
         );
     }
 
-    public function maxData()
+    public static function maxData()
     {
         return [
             [5, 5],

--- a/tests/Operator/MinTest.php
+++ b/tests/Operator/MinTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -17,9 +18,7 @@ class MinTest extends TestCase
         $this->assertInstanceOf(\Ruler\VariableOperand::class, $op);
     }
 
-    /**
-     * @dataProvider invalidData
-     */
+    #[DataProvider('invalidData')]
     public function testInvalidData($datum)
     {
         $this->expectException(\RuntimeException::class);
@@ -31,7 +30,7 @@ class MinTest extends TestCase
         $op->prepareValue($context);
     }
 
-    public function invalidData()
+    public static function invalidData()
     {
         return [
             ['string'],
@@ -41,9 +40,7 @@ class MinTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider minData
-     */
+    #[DataProvider('minData')]
     public function testMin($a, $result)
     {
         $var = new Variable('a', $a);
@@ -56,7 +53,7 @@ class MinTest extends TestCase
         );
     }
 
-    public function minData()
+    public static function minData()
     {
         return [
             [5, 5],

--- a/tests/Operator/ModuloTest.php
+++ b/tests/Operator/ModuloTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -42,9 +43,7 @@ class ModuloTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider moduloData
-     */
+    #[DataProvider('moduloData')]
     public function testModulo($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -55,7 +54,7 @@ class ModuloTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function moduloData()
+    public static function moduloData()
     {
         return [
             [6, 2, 0],

--- a/tests/Operator/MultiplicationTest.php
+++ b/tests/Operator/MultiplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -30,9 +31,7 @@ class MultiplicationTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider multiplyData
-     */
+    #[DataProvider('multiplyData')]
     public function testMultiply($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -43,7 +42,7 @@ class MultiplicationTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function multiplyData()
+    public static function multiplyData()
     {
         return [
             [6, 2, 12],

--- a/tests/Operator/NegationTest.php
+++ b/tests/Operator/NegationTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -28,9 +29,8 @@ class NegationTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider negateData
-     */
+    #[DataProvider('negateData')]
+
     public function testSubtract($a, $result)
     {
         $varA = new Variable('a', $a);
@@ -40,7 +40,7 @@ class NegationTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function negateData()
+    public static function negateData()
     {
         return [
             [1, -1],

--- a/tests/Operator/NegationTest.php
+++ b/tests/Operator/NegationTest.php
@@ -30,7 +30,6 @@ class NegationTest extends TestCase
     }
 
     #[DataProvider('negateData')]
-
     public function testSubtract($a, $result)
     {
         $varA = new Variable('a', $a);

--- a/tests/Operator/SetContainsTest.php
+++ b/tests/Operator/SetContainsTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -18,9 +19,7 @@ class SetContainsTest extends TestCase
         $this->assertInstanceOf(\Ruler\Proposition::class, $op);
     }
 
-    /**
-     * @dataProvider containsData
-     */
+    #[DataProvider('containsData')]
     public function testContains($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -31,9 +30,7 @@ class SetContainsTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    /**
-     * @dataProvider containsData
-     */
+    #[DataProvider('containsData')]
     public function testDoesNotContain($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -44,7 +41,7 @@ class SetContainsTest extends TestCase
         $this->assertNotEquals($op->evaluate($context), $result);
     }
 
-    public function containsData()
+    public static function containsData()
     {
         return [
             [[1], 1, true],

--- a/tests/Operator/StartsWithInsensitiveTest.php
+++ b/tests/Operator/StartsWithInsensitiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -18,9 +19,7 @@ class StartsWithInsensitiveTest extends TestCase
         $this->assertInstanceOf(\Ruler\Proposition::class, $op);
     }
 
-    /**
-     * @dataProvider startsWithData
-     */
+    #[DataProvider('startsWithData')]
     public function testStartsWithInsensitive($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -31,7 +30,7 @@ class StartsWithInsensitiveTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    public function startsWithData()
+    public static function startsWithData()
     {
         return [
             ['supercalifragilistic', 'supercalifragilistic', true],

--- a/tests/Operator/StartsWithTest.php
+++ b/tests/Operator/StartsWithTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -18,9 +19,7 @@ class StartsWithTest extends TestCase
         $this->assertInstanceOf(\Ruler\Proposition::class, $op);
     }
 
-    /**
-     * @dataProvider startsWithData
-     */
+    #[DataProvider('startsWithData')]
     public function testStartsWith($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -31,7 +30,7 @@ class StartsWithTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    public function startsWithData()
+    public static function startsWithData()
     {
         return [
             ['supercalifragilistic', 'supercalifragilistic', true],

--- a/tests/Operator/StringContainsInsensitiveTest.php
+++ b/tests/Operator/StringContainsInsensitiveTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -31,9 +32,7 @@ class StringContainsInsensitiveTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    /**
-     * @dataProvider containsData
-     */
+    #[DataProvider('containsData')]
     public function testDoesNotContain($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -44,7 +43,7 @@ class StringContainsInsensitiveTest extends TestCase
         $this->assertNotEquals($op->evaluate($context), $result);
     }
 
-    public function containsData()
+    public static function containsData()
     {
         return [
             ['supercalifragilistic', 'super', true],

--- a/tests/Operator/StringContainsTest.php
+++ b/tests/Operator/StringContainsTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -31,9 +32,7 @@ class StringContainsTest extends TestCase
         $this->assertEquals($op->evaluate($context), $result);
     }
 
-    /**
-     * @dataProvider containsData
-     */
+    #[DataProvider('containsData')]
     public function testDoesNotContain($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -44,7 +43,7 @@ class StringContainsTest extends TestCase
         $this->assertNotEquals($op->evaluate($context), $result);
     }
 
-    public function containsData()
+    public static function containsData()
     {
         return [
             ['supercalifragilistic', 'super', true],

--- a/tests/Operator/SubtractionTest.php
+++ b/tests/Operator/SubtractionTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -30,9 +31,7 @@ class SubtractionTest extends TestCase
         $op->prepareValue($context);
     }
 
-    /**
-     * @dataProvider subtractData
-     */
+    #[DataProvider('subtractData')]
     public function testSubtract($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -43,7 +42,7 @@ class SubtractionTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function subtractData()
+    public static function subtractData()
     {
         return [
             [6, 2, 4],

--- a/tests/Operator/SymmetricDifferenceTest.php
+++ b/tests/Operator/SymmetricDifferenceTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -31,9 +32,7 @@ class SymmetricDifferenceTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider symmetricDifferenceData
-     */
+    #[DataProvider('symmetricDifferenceData')]
     public function testSymmetricDifference($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -47,7 +46,7 @@ class SymmetricDifferenceTest extends TestCase
         );
     }
 
-    public function symmetricDifferenceData()
+    public static function symmetricDifferenceData()
     {
         return [
             [6, 2, [6, 2]],

--- a/tests/Operator/UnionTest.php
+++ b/tests/Operator/UnionTest.php
@@ -2,6 +2,7 @@
 
 namespace Ruler\Test\Operator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ruler\Context;
 use Ruler\Operator;
@@ -34,9 +35,7 @@ class UnionTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider unionData
-     */
+    #[DataProvider('unionData')]
     public function testUnion($a, $b, $result)
     {
         $varA = new Variable('a', $a);
@@ -47,7 +46,7 @@ class UnionTest extends TestCase
         $this->assertEquals($op->prepareValue($context)->getValue(), $result);
     }
 
-    public function unionData()
+    public static function unionData()
     {
         return [
             [6, 2, [6, 2]],

--- a/tests/ValueTest.php
+++ b/tests/ValueTest.php
@@ -3,6 +3,7 @@
 namespace Ruler\Test;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Ruler\Value;
 
 class ValueTest extends TestCase
@@ -14,9 +15,7 @@ class ValueTest extends TestCase
         $this->assertEquals($valueString, $value->getValue());
     }
 
-    /**
-     * @dataProvider getRelativeValues
-     */
+    #[DataProvider('getRelativeValues')]
     public function testGreaterThanEqualToAndLessThan($a, $b, $gt, $eq, $lt)
     {
         $valA = new Value($a);
@@ -27,7 +26,7 @@ class ValueTest extends TestCase
         $this->assertEquals($eq, $valA->equalTo($valB));
     }
 
-    public function getRelativeValues()
+    public static function getRelativeValues()
     {
         return [
             [1, 2,     false, false, true],

--- a/tests/ValueTest.php
+++ b/tests/ValueTest.php
@@ -2,8 +2,8 @@
 
 namespace Ruler\Test;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 use Ruler\Value;
 
 class ValueTest extends TestCase


### PR DESCRIPTION
PHP 8.4 Support
 * [PHP]  Removes support for 8.0 and older
 * [PHP] Adds 8.4 support
   * Updates Ruler\Variable to allow for nullable name
   * Update Ruler\Variable constructor doc block
   * Updates Ruler\RuleBuilder\Variable to allow for nullable name
   * Updates Ruler\RuleBuilder\Variable to identify value as `mixed`
   * Update Ruler\RuleBuilder\Variable constructor doc block
   * Updates Ruler\Value::$value to be identified as `mixed`
   * Adds return type declaration to  Ruler\Value::getValue() 
 * [phpunit] Updates test to use attributes
 * [phpunit]  Updates `phpunit/phpunit` to use 10.5 
   * 10.5 still maintains 8.1 support
   * After 8.1 reaches EOL recommend moving to 11.x 
 * Updates README to remove references for 5.3 and replaces with 8.1
